### PR TITLE
Add Azure load balancer component

### DIFF
--- a/atmos/components/terraform/modules/azure-loadbalancer/README.md
+++ b/atmos/components/terraform/modules/azure-loadbalancer/README.md
@@ -1,0 +1,543 @@
+# Azure Load Balancer Terraform Module
+
+This module creates and manages an Azure Load Balancer with support for frontend IP configurations, backend address pools, health probes, load balancing rules, NAT rules, NAT pools, and outbound rules.
+
+## Features
+
+- **Multiple SKU Support**: Basic, Standard, and Gateway SKUs
+- **Frontend IP Configurations**: Support for both public and private IP addresses
+- **Backend Address Pools**: Multiple backend pools with optional tunnel interfaces
+- **Health Probes**: TCP, HTTP, and HTTPS health probes with customizable thresholds
+- **Load Balancing Rules**: Flexible load distribution with multiple algorithms
+- **Inbound NAT Rules**: Port forwarding for individual backend instances
+- **NAT Pools**: Port address translation for VM scale sets
+- **Outbound Rules**: Configure outbound connectivity for Standard SKU
+- **Zone Redundancy**: Support for availability zones
+- **CloudPosse Label Integration**: Consistent naming and tagging using the label module
+- **Conditional Creation**: Enable/disable resource creation with a single variable
+
+## Usage
+
+### Basic Public Load Balancer
+
+```hcl
+module "public_loadbalancer" {
+  source = "../../modules/azure-loadbalancer"
+
+  enabled             = true
+  location            = "eastus"
+  resource_group_name = "rg-network-prod"
+
+  sku      = "Standard"
+  sku_tier = "Regional"
+
+  frontend_ip_configurations = [
+    {
+      name                 = "public-frontend"
+      public_ip_address_id = azurerm_public_ip.example.id
+      zones                = ["1", "2", "3"]
+    }
+  ]
+
+  backend_address_pools = {
+    web-pool = {
+      name = "web-backend-pool"
+    }
+  }
+
+  probes = {
+    http-probe = {
+      name                = "http-health-probe"
+      protocol            = "Http"
+      port                = 80
+      request_path        = "/health"
+      interval_in_seconds = 15
+      number_of_probes    = 2
+    }
+  }
+
+  load_balancing_rules = {
+    http-rule = {
+      name                           = "http-lb-rule"
+      protocol                       = "Tcp"
+      frontend_port                  = 80
+      backend_port                   = 80
+      frontend_ip_configuration_name = "public-frontend"
+      backend_address_pool_keys      = ["web-pool"]
+      probe_key                      = "http-probe"
+      enable_tcp_reset               = true
+      idle_timeout_in_minutes        = 4
+    }
+  }
+
+  # Label module configuration
+  namespace   = "acme"
+  environment = "eus"
+  stage       = "prod"
+  name        = "web-lb"
+  tags = {
+    ManagedBy = "Terraform"
+    Purpose   = "Web Traffic"
+  }
+}
+```
+
+### Internal Load Balancer with Multiple Backend Pools
+
+```hcl
+module "internal_loadbalancer" {
+  source = "../../modules/azure-loadbalancer"
+
+  enabled             = true
+  location            = "westeurope"
+  resource_group_name = "rg-network-prod"
+
+  sku      = "Standard"
+  sku_tier = "Regional"
+
+  frontend_ip_configurations = [
+    {
+      name                          = "internal-frontend"
+      subnet_id                     = azurerm_subnet.backend.id
+      private_ip_address            = "10.0.1.100"
+      private_ip_address_allocation = "Static"
+      private_ip_address_version    = "IPv4"
+      zones                         = ["1", "2", "3"]
+    }
+  ]
+
+  backend_address_pools = {
+    app-pool = {
+      name = "application-pool"
+    }
+    db-pool = {
+      name = "database-pool"
+    }
+  }
+
+  probes = {
+    app-probe = {
+      name                = "app-tcp-probe"
+      protocol            = "Tcp"
+      port                = 8080
+      interval_in_seconds = 10
+      number_of_probes    = 3
+    }
+    db-probe = {
+      name                = "db-tcp-probe"
+      protocol            = "Tcp"
+      port                = 5432
+      interval_in_seconds = 10
+      number_of_probes    = 3
+    }
+  }
+
+  load_balancing_rules = {
+    app-rule = {
+      name                           = "app-lb-rule"
+      protocol                       = "Tcp"
+      frontend_port                  = 8080
+      backend_port                   = 8080
+      frontend_ip_configuration_name = "internal-frontend"
+      backend_address_pool_keys      = ["app-pool"]
+      probe_key                      = "app-probe"
+      enable_tcp_reset               = true
+      load_distribution              = "SourceIPProtocol"
+    }
+    db-rule = {
+      name                           = "db-lb-rule"
+      protocol                       = "Tcp"
+      frontend_port                  = 5432
+      backend_port                   = 5432
+      frontend_ip_configuration_name = "internal-frontend"
+      backend_address_pool_keys      = ["db-pool"]
+      probe_key                      = "db-probe"
+      enable_tcp_reset               = true
+    }
+  }
+
+  namespace   = "acme"
+  environment = "weu"
+  stage       = "prod"
+  name        = "internal-lb"
+  tags = {
+    ManagedBy = "Terraform"
+    Purpose   = "Internal Services"
+  }
+}
+```
+
+### Advanced Configuration with NAT Rules and Outbound Rules
+
+```hcl
+module "advanced_loadbalancer" {
+  source = "../../modules/azure-loadbalancer"
+
+  enabled             = true
+  location            = "eastus2"
+  resource_group_name = "rg-network-prod"
+
+  sku      = "Standard"
+  sku_tier = "Regional"
+
+  frontend_ip_configurations = [
+    {
+      name                 = "public-frontend-1"
+      public_ip_address_id = azurerm_public_ip.lb_pip_1.id
+      zones                = ["1", "2", "3"]
+    },
+    {
+      name                 = "public-frontend-2"
+      public_ip_address_id = azurerm_public_ip.lb_pip_2.id
+      zones                = ["1", "2", "3"]
+    }
+  ]
+
+  backend_address_pools = {
+    primary-pool = {
+      name = "primary-backend-pool"
+    }
+  }
+
+  probes = {
+    https-probe = {
+      name                = "https-health-probe"
+      protocol            = "Https"
+      port                = 443
+      request_path        = "/api/health"
+      interval_in_seconds = 15
+      number_of_probes    = 2
+      probe_threshold     = 1
+    }
+  }
+
+  load_balancing_rules = {
+    https-rule = {
+      name                           = "https-lb-rule"
+      protocol                       = "Tcp"
+      frontend_port                  = 443
+      backend_port                   = 443
+      frontend_ip_configuration_name = "public-frontend-1"
+      backend_address_pool_keys      = ["primary-pool"]
+      probe_key                      = "https-probe"
+      enable_tcp_reset               = true
+      disable_outbound_snat          = true
+      idle_timeout_in_minutes        = 15
+    }
+  }
+
+  nat_rules = {
+    ssh-vm1 = {
+      name                           = "ssh-nat-vm1"
+      protocol                       = "Tcp"
+      frontend_port                  = 22001
+      backend_port                   = 22
+      frontend_ip_configuration_name = "public-frontend-2"
+      enable_tcp_reset               = true
+    }
+    ssh-vm2 = {
+      name                           = "ssh-nat-vm2"
+      protocol                       = "Tcp"
+      frontend_port                  = 22002
+      backend_port                   = 22
+      frontend_ip_configuration_name = "public-frontend-2"
+      enable_tcp_reset               = true
+    }
+  }
+
+  outbound_rules = {
+    outbound = {
+      name                             = "outbound-rule"
+      protocol                         = "All"
+      backend_address_pool_key         = "primary-pool"
+      frontend_ip_configuration_names  = ["public-frontend-1", "public-frontend-2"]
+      allocated_outbound_ports         = 1024
+      idle_timeout_in_minutes          = 4
+      enable_tcp_reset                 = true
+    }
+  }
+
+  namespace   = "acme"
+  environment = "eus2"
+  stage       = "prod"
+  name        = "advanced-lb"
+  delimiter   = "-"
+  tags = {
+    ManagedBy   = "Terraform"
+    Purpose     = "Production Services"
+    Criticality = "High"
+  }
+}
+```
+
+### Development Environment
+
+```hcl
+module "dev_loadbalancer" {
+  source = "../../modules/azure-loadbalancer"
+
+  enabled             = true
+  location            = "eastus"
+  resource_group_name = "rg-network-dev"
+
+  sku      = "Basic"
+  sku_tier = "Regional"
+
+  frontend_ip_configurations = [
+    {
+      name                 = "dev-frontend"
+      public_ip_address_id = azurerm_public_ip.dev.id
+    }
+  ]
+
+  backend_address_pools = {
+    dev-pool = {
+      name = "dev-backend-pool"
+    }
+  }
+
+  probes = {
+    tcp-probe = {
+      name                = "tcp-probe"
+      protocol            = "Tcp"
+      port                = 80
+      interval_in_seconds = 15
+      number_of_probes    = 2
+    }
+  }
+
+  load_balancing_rules = {
+    http = {
+      name                           = "http-rule"
+      protocol                       = "Tcp"
+      frontend_port                  = 80
+      backend_port                   = 80
+      frontend_ip_configuration_name = "dev-frontend"
+      backend_address_pool_keys      = ["dev-pool"]
+      probe_key                      = "tcp-probe"
+    }
+  }
+
+  namespace   = "acme"
+  environment = "eus"
+  stage       = "dev"
+  name        = "lb"
+  tags = {
+    ManagedBy   = "Terraform"
+    Environment = "Development"
+    CostCenter  = "Engineering"
+  }
+}
+```
+
+## Atmos Stack Configuration
+
+```yaml
+components:
+  terraform:
+    azure-loadbalancer:
+      metadata:
+        component: azure-loadbalancer
+        type: real
+      vars:
+        enabled: true
+        location: "eastus"
+        resource_group_name: "rg-network-prod"
+
+        sku: "Standard"
+        sku_tier: "Regional"
+
+        frontend_ip_configurations:
+          - name: "public-frontend"
+            public_ip_address_id: "{{ outputs.azure-public-ip.id }}"
+            zones: ["1", "2", "3"]
+
+        backend_address_pools:
+          web-pool:
+            name: "web-backend-pool"
+
+        probes:
+          http-probe:
+            name: "http-health-probe"
+            protocol: "Http"
+            port: 80
+            request_path: "/health"
+            interval_in_seconds: 15
+            number_of_probes: 2
+
+        load_balancing_rules:
+          http-rule:
+            name: "http-lb-rule"
+            protocol: "Tcp"
+            frontend_port: 80
+            backend_port: 80
+            frontend_ip_configuration_name: "public-frontend"
+            backend_address_pool_keys: ["web-pool"]
+            probe_key: "http-probe"
+            enable_tcp_reset: true
+
+        namespace: "acme"
+        environment: "eus"
+        stage: "prod"
+        name: "web-lb"
+        delimiter: "-"
+        tags:
+          ManagedBy: "Terraform"
+          Purpose: "Web Traffic"
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.9.0 |
+| azurerm | = 4.20.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| azurerm | = 4.20.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| label | cloudposse/label/null | 0.25.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_lb.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb) | resource |
+| [azurerm_lb_backend_address_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb_backend_address_pool) | resource |
+| [azurerm_lb_probe.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb_probe) | resource |
+| [azurerm_lb_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb_rule) | resource |
+| [azurerm_lb_nat_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb_nat_rule) | resource |
+| [azurerm_lb_nat_pool.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb_nat_pool) | resource |
+| [azurerm_lb_outbound_rule.this](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb_outbound_rule) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| location | The Azure Region where the Load Balancer should exist | `string` | n/a | yes |
+| resource_group_name | The name of the Resource Group where the Load Balancer should exist | `string` | n/a | yes |
+| loadbalancer_name | Specifies the name of the Load Balancer. If not provided, the name will be generated using the label module | `string` | `null` | no |
+| sku | The SKU of the Azure Load Balancer. Accepted values are Basic, Standard and Gateway | `string` | `"Standard"` | no |
+| sku_tier | The SKU tier of this Load Balancer. Possible values are Global and Regional | `string` | `"Regional"` | no |
+| edge_zone | Specifies the Edge Zone within the Azure Region where this Load Balancer should exist | `string` | `null` | no |
+| frontend_ip_configurations | List of frontend IP configurations for the Load Balancer | `list(object)` | `[]` | no |
+| backend_address_pools | Map of backend address pools for the Load Balancer | `map(object)` | `{}` | no |
+| probes | Map of health probes for the Load Balancer | `map(object)` | `{}` | no |
+| load_balancing_rules | Map of load balancing rules for the Load Balancer | `map(object)` | `{}` | no |
+| nat_rules | Map of inbound NAT rules for the Load Balancer | `map(object)` | `{}` | no |
+| nat_pools | Map of NAT pools for the Load Balancer | `map(object)` | `{}` | no |
+| outbound_rules | Map of outbound rules for the Load Balancer (Standard SKU only) | `map(object)` | `{}` | no |
+| namespace | ID element. Usually an abbreviation of your organization name | `string` | `null` | no |
+| tenant | ID element. Usually used to indicate the tenant identifier | `string` | `null` | no |
+| environment | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| stage | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| name | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| attributes | ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id` | `list(string)` | `[]` | no |
+| delimiter | Delimiter to be used between ID elements | `string` | `"-"` | no |
+| tags | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`) | `map(string)` | `{}` | no |
+| regex_replace_chars | Regex to replace characters in ID elements | `string` | `null` | no |
+| label_order | The order in which the labels appear in the `id` | `list(string)` | `null` | no |
+| label_key_case | Controls the letter case of tag keys | `string` | `null` | no |
+| label_value_case | Controls the letter case of ID elements | `string` | `null` | no |
+| id_length_limit | Limit `id` to this many characters (minimum 6) | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The ID of the Load Balancer |
+| name | The name of the Load Balancer |
+| frontend_ip_configuration | The frontend IP configuration of the Load Balancer |
+| frontend_ip_configuration_ids | Map of frontend IP configuration names to their IDs |
+| backend_address_pool_ids | Map of backend address pool names to their IDs |
+| probe_ids | Map of probe names to their IDs |
+| load_balancing_rule_ids | Map of load balancing rule names to their IDs |
+| nat_rule_ids | Map of NAT rule names to their IDs |
+| nat_pool_ids | Map of NAT pool names to their IDs |
+| outbound_rule_ids | Map of outbound rule names to their IDs |
+| private_ip_address | The first private IP address assigned to the load balancer |
+| private_ip_addresses | The list of private IP addresses assigned to the load balancer |
+| label_id | The generated ID from the label module |
+| tags | The tags applied to the Load Balancer |
+| context | Exported context from the label module |
+
+## Notes
+
+### SKU Considerations
+
+- **Basic SKU**:
+  - Supports up to 300 instances
+  - Open by default (no Network Security Groups required)
+  - Does not support Availability Zones
+  - Does not support outbound rules
+  - Free tier
+
+- **Standard SKU**:
+  - Supports up to 1000 instances
+  - Secure by default (requires Network Security Groups)
+  - Supports Availability Zones
+  - Supports outbound rules for SNAT
+  - Zone-redundant and zonal frontends
+  - Charged based on rules and data processed
+
+- **Gateway SKU**:
+  - For third-party network virtual appliances
+  - Supports chain of network virtual appliances
+
+### Load Distribution Algorithms
+
+The `load_distribution` parameter supports the following values:
+
+- **Default**: Five-tuple hash (source IP, source port, destination IP, destination port, protocol)
+- **SourceIP**: Two-tuple hash (source IP, destination IP) - session affinity
+- **SourceIPProtocol**: Three-tuple hash (source IP, destination IP, protocol)
+
+### Health Probe Protocols
+
+- **Tcp**: Simple TCP connection check
+- **Http**: HTTP GET request with 200-399 response expected
+- **Https**: HTTPS GET request with 200-399 response expected
+
+### Availability Zones
+
+When using availability zones:
+- Specify zones in `frontend_ip_configurations` as a list (e.g., `["1", "2", "3"]`)
+- Zone-redundant deployment requires Standard SKU
+- Public IP addresses must also be zone-redundant or zonal
+
+### Outbound Connectivity
+
+For Standard SKU Load Balancers:
+- Outbound rules control SNAT port allocation
+- `allocated_outbound_ports` should be calculated based on backend pool size
+- Formula: `(frontend IPs × 64K) / backend instances`
+- Use multiple frontend IPs for higher SNAT port capacity
+
+### Resource Dependencies
+
+Load Balancer resources must be created in this order:
+1. Load Balancer
+2. Backend Address Pools
+3. Probes
+4. Load Balancing Rules (depends on pools and probes)
+5. NAT Rules/Pools
+6. Outbound Rules (depends on pools)
+
+This module handles these dependencies automatically.
+
+## References
+
+- [Azure Load Balancer Documentation](https://learn.microsoft.com/en-us/azure/load-balancer/)
+- [Azure Load Balancer SKUs](https://learn.microsoft.com/en-us/azure/load-balancer/skus)
+- [Load Balancer Health Probes](https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-custom-probe-overview)
+- [Outbound Rules](https://learn.microsoft.com/en-us/azure/load-balancer/outbound-rules)
+- [AzureRM Load Balancer Resource](https://registry.terraform.io/providers/hashicorp/azurerm/4.20.0/docs/resources/lb)
+- [CloudPosse Label Module](https://registry.terraform.io/modules/cloudposse/label/null/latest)

--- a/atmos/components/terraform/modules/azure-loadbalancer/main.tf
+++ b/atmos/components/terraform/modules/azure-loadbalancer/main.tf
@@ -1,0 +1,152 @@
+module "label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  attributes          = var.attributes
+  delimiter           = var.delimiter
+  tags                = var.tags
+  regex_replace_chars = var.regex_replace_chars
+  label_order         = var.label_order
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  id_length_limit     = var.id_length_limit
+}
+
+locals {
+  loadbalancer_name = var.enabled ? coalesce(var.loadbalancer_name, module.label.id) : null
+}
+
+resource "azurerm_lb" "this" {
+  count = var.enabled ? 1 : 0
+
+  name                = local.loadbalancer_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = var.sku
+  sku_tier            = var.sku_tier
+  edge_zone           = var.edge_zone
+
+  dynamic "frontend_ip_configuration" {
+    for_each = var.frontend_ip_configurations
+
+    content {
+      name                                               = frontend_ip_configuration.value.name
+      zones                                              = frontend_ip_configuration.value.zones
+      subnet_id                                          = frontend_ip_configuration.value.subnet_id
+      gateway_load_balancer_frontend_ip_configuration_id = frontend_ip_configuration.value.gateway_load_balancer_frontend_ip_configuration_id
+      private_ip_address                                 = frontend_ip_configuration.value.private_ip_address
+      private_ip_address_allocation                      = frontend_ip_configuration.value.private_ip_address_allocation
+      private_ip_address_version                         = frontend_ip_configuration.value.private_ip_address_version
+      public_ip_address_id                               = frontend_ip_configuration.value.public_ip_address_id
+      public_ip_prefix_id                                = frontend_ip_configuration.value.public_ip_prefix_id
+    }
+  }
+
+  tags = module.label.tags
+}
+
+resource "azurerm_lb_backend_address_pool" "this" {
+  for_each = var.enabled ? var.backend_address_pools : {}
+
+  name            = each.value.name
+  loadbalancer_id = azurerm_lb.this[0].id
+
+  dynamic "tunnel_interface" {
+    for_each = each.value.tunnel_interfaces != null ? each.value.tunnel_interfaces : []
+
+    content {
+      identifier = tunnel_interface.value.identifier
+      type       = tunnel_interface.value.type
+      protocol   = tunnel_interface.value.protocol
+      port       = tunnel_interface.value.port
+    }
+  }
+}
+
+resource "azurerm_lb_probe" "this" {
+  for_each = var.enabled ? var.probes : {}
+
+  name                = each.value.name
+  loadbalancer_id     = azurerm_lb.this[0].id
+  protocol            = each.value.protocol
+  port                = each.value.port
+  request_path        = each.value.request_path
+  interval_in_seconds = each.value.interval_in_seconds
+  number_of_probes    = each.value.number_of_probes
+  probe_threshold     = each.value.probe_threshold
+}
+
+resource "azurerm_lb_rule" "this" {
+  for_each = var.enabled ? var.load_balancing_rules : {}
+
+  name                           = each.value.name
+  loadbalancer_id                = azurerm_lb.this[0].id
+  protocol                       = each.value.protocol
+  frontend_port                  = each.value.frontend_port
+  backend_port                   = each.value.backend_port
+  frontend_ip_configuration_name = each.value.frontend_ip_configuration_name
+  backend_address_pool_ids       = [for pool_key in each.value.backend_address_pool_keys : azurerm_lb_backend_address_pool.this[pool_key].id]
+  probe_id                       = each.value.probe_key != null ? azurerm_lb_probe.this[each.value.probe_key].id : null
+  enable_floating_ip             = each.value.enable_floating_ip
+  enable_tcp_reset               = each.value.enable_tcp_reset
+  disable_outbound_snat          = each.value.disable_outbound_snat
+  idle_timeout_in_minutes        = each.value.idle_timeout_in_minutes
+  load_distribution              = each.value.load_distribution
+}
+
+resource "azurerm_lb_nat_rule" "this" {
+  for_each = var.enabled ? var.nat_rules : {}
+
+  name                           = each.value.name
+  resource_group_name            = var.resource_group_name
+  loadbalancer_id                = azurerm_lb.this[0].id
+  protocol                       = each.value.protocol
+  frontend_port                  = each.value.frontend_port
+  backend_port                   = each.value.backend_port
+  frontend_ip_configuration_name = each.value.frontend_ip_configuration_name
+  idle_timeout_in_minutes        = each.value.idle_timeout_in_minutes
+  enable_floating_ip             = each.value.enable_floating_ip
+  enable_tcp_reset               = each.value.enable_tcp_reset
+  backend_address_pool_id        = each.value.backend_address_pool_key != null ? azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_key].id : null
+}
+
+resource "azurerm_lb_nat_pool" "this" {
+  for_each = var.enabled ? var.nat_pools : {}
+
+  name                           = each.value.name
+  resource_group_name            = var.resource_group_name
+  loadbalancer_id                = azurerm_lb.this[0].id
+  protocol                       = each.value.protocol
+  frontend_port_start            = each.value.frontend_port_start
+  frontend_port_end              = each.value.frontend_port_end
+  backend_port                   = each.value.backend_port
+  frontend_ip_configuration_name = each.value.frontend_ip_configuration_name
+  idle_timeout_in_minutes        = each.value.idle_timeout_in_minutes
+  floating_ip_enabled            = each.value.floating_ip_enabled
+  tcp_reset_enabled              = each.value.tcp_reset_enabled
+}
+
+resource "azurerm_lb_outbound_rule" "this" {
+  for_each = var.enabled ? var.outbound_rules : {}
+
+  name                     = each.value.name
+  loadbalancer_id          = azurerm_lb.this[0].id
+  protocol                 = each.value.protocol
+  backend_address_pool_id  = azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_key].id
+  allocated_outbound_ports = each.value.allocated_outbound_ports
+  idle_timeout_in_minutes  = each.value.idle_timeout_in_minutes
+  enable_tcp_reset         = each.value.enable_tcp_reset
+
+  dynamic "frontend_ip_configuration" {
+    for_each = each.value.frontend_ip_configuration_names
+
+    content {
+      name = frontend_ip_configuration.value
+    }
+  }
+}

--- a/atmos/components/terraform/modules/azure-loadbalancer/main.tf
+++ b/atmos/components/terraform/modules/azure-loadbalancer/main.tf
@@ -112,7 +112,6 @@ resource "azurerm_lb_nat_rule" "this" {
   idle_timeout_in_minutes        = each.value.idle_timeout_in_minutes
   enable_floating_ip             = each.value.enable_floating_ip
   enable_tcp_reset               = each.value.enable_tcp_reset
-  backend_address_pool_id        = each.value.backend_address_pool_key != null ? azurerm_lb_backend_address_pool.this[each.value.backend_address_pool_key].id : null
 }
 
 resource "azurerm_lb_nat_pool" "this" {

--- a/atmos/components/terraform/modules/azure-loadbalancer/outputs.tf
+++ b/atmos/components/terraform/modules/azure-loadbalancer/outputs.tf
@@ -1,0 +1,89 @@
+output "id" {
+  description = "The ID of the Load Balancer"
+  value       = var.enabled ? azurerm_lb.this[0].id : ""
+}
+
+output "name" {
+  description = "The name of the Load Balancer"
+  value       = var.enabled ? azurerm_lb.this[0].name : ""
+}
+
+output "frontend_ip_configuration" {
+  description = "The frontend IP configuration of the Load Balancer"
+  value       = var.enabled ? azurerm_lb.this[0].frontend_ip_configuration : []
+}
+
+output "frontend_ip_configuration_ids" {
+  description = "Map of frontend IP configuration names to their IDs"
+  value = var.enabled ? {
+    for config in azurerm_lb.this[0].frontend_ip_configuration :
+    config.name => config.id
+  } : {}
+}
+
+output "backend_address_pool_ids" {
+  description = "Map of backend address pool names to their IDs"
+  value = var.enabled ? {
+    for k, v in azurerm_lb_backend_address_pool.this : k => v.id
+  } : {}
+}
+
+output "probe_ids" {
+  description = "Map of probe names to their IDs"
+  value = var.enabled ? {
+    for k, v in azurerm_lb_probe.this : k => v.id
+  } : {}
+}
+
+output "load_balancing_rule_ids" {
+  description = "Map of load balancing rule names to their IDs"
+  value = var.enabled ? {
+    for k, v in azurerm_lb_rule.this : k => v.id
+  } : {}
+}
+
+output "nat_rule_ids" {
+  description = "Map of NAT rule names to their IDs"
+  value = var.enabled ? {
+    for k, v in azurerm_lb_nat_rule.this : k => v.id
+  } : {}
+}
+
+output "nat_pool_ids" {
+  description = "Map of NAT pool names to their IDs"
+  value = var.enabled ? {
+    for k, v in azurerm_lb_nat_pool.this : k => v.id
+  } : {}
+}
+
+output "outbound_rule_ids" {
+  description = "Map of outbound rule names to their IDs"
+  value = var.enabled ? {
+    for k, v in azurerm_lb_outbound_rule.this : k => v.id
+  } : {}
+}
+
+output "private_ip_address" {
+  description = "The first private IP address assigned to the load balancer in frontend_ip_configuration blocks, if any"
+  value       = var.enabled ? azurerm_lb.this[0].private_ip_address : ""
+}
+
+output "private_ip_addresses" {
+  description = "The list of private IP addresses assigned to the load balancer in frontend_ip_configuration blocks, if any"
+  value       = var.enabled ? azurerm_lb.this[0].private_ip_addresses : []
+}
+
+output "label_id" {
+  description = "The generated ID from the label module"
+  value       = module.label.id
+}
+
+output "tags" {
+  description = "The tags applied to the Load Balancer"
+  value       = module.label.tags
+}
+
+output "context" {
+  description = "Exported context from the label module for use by other modules"
+  value       = module.label.context
+}

--- a/atmos/components/terraform/modules/azure-loadbalancer/providers.tf
+++ b/atmos/components/terraform/modules/azure-loadbalancer/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "= 4.20.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/atmos/components/terraform/modules/azure-loadbalancer/variables.tf
+++ b/atmos/components/terraform/modules/azure-loadbalancer/variables.tf
@@ -120,7 +120,6 @@ variable "nat_rules" {
     idle_timeout_in_minutes        = optional(number)
     enable_floating_ip             = optional(bool)
     enable_tcp_reset               = optional(bool)
-    backend_address_pool_key       = optional(string)
   }))
   default = {}
 }

--- a/atmos/components/terraform/modules/azure-loadbalancer/variables.tf
+++ b/atmos/components/terraform/modules/azure-loadbalancer/variables.tf
@@ -1,0 +1,235 @@
+variable "enabled" {
+  description = "Set to false to prevent the module from creating any resources"
+  type        = bool
+  default     = true
+}
+
+variable "location" {
+  description = "The Azure Region where the Load Balancer should exist"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the Resource Group where the Load Balancer should exist"
+  type        = string
+}
+
+variable "loadbalancer_name" {
+  description = "Specifies the name of the Load Balancer. If not provided, the name will be generated using the label module"
+  type        = string
+  default     = null
+}
+
+variable "sku" {
+  description = "The SKU of the Azure Load Balancer. Accepted values are Basic, Standard and Gateway"
+  type        = string
+  default     = "Standard"
+  validation {
+    condition     = contains(["Basic", "Standard", "Gateway"], var.sku)
+    error_message = "SKU must be one of: Basic, Standard, Gateway"
+  }
+}
+
+variable "sku_tier" {
+  description = "The SKU tier of this Load Balancer. Possible values are Global and Regional"
+  type        = string
+  default     = "Regional"
+  validation {
+    condition     = contains(["Global", "Regional"], var.sku_tier)
+    error_message = "SKU tier must be one of: Global, Regional"
+  }
+}
+
+variable "edge_zone" {
+  description = "Specifies the Edge Zone within the Azure Region where this Load Balancer should exist"
+  type        = string
+  default     = null
+}
+
+variable "frontend_ip_configurations" {
+  description = "List of frontend IP configurations for the Load Balancer"
+  type = list(object({
+    name                                               = string
+    zones                                              = optional(list(string))
+    subnet_id                                          = optional(string)
+    gateway_load_balancer_frontend_ip_configuration_id = optional(string)
+    private_ip_address                                 = optional(string)
+    private_ip_address_allocation                      = optional(string)
+    private_ip_address_version                         = optional(string)
+    public_ip_address_id                               = optional(string)
+    public_ip_prefix_id                                = optional(string)
+  }))
+  default = []
+}
+
+variable "backend_address_pools" {
+  description = "Map of backend address pools for the Load Balancer"
+  type = map(object({
+    name = string
+    tunnel_interfaces = optional(list(object({
+      identifier = number
+      type       = string
+      protocol   = string
+      port       = number
+    })))
+  }))
+  default = {}
+}
+
+variable "probes" {
+  description = "Map of health probes for the Load Balancer"
+  type = map(object({
+    name                = string
+    protocol            = string
+    port                = number
+    request_path        = optional(string)
+    interval_in_seconds = optional(number)
+    number_of_probes    = optional(number)
+    probe_threshold     = optional(number)
+  }))
+  default = {}
+}
+
+variable "load_balancing_rules" {
+  description = "Map of load balancing rules for the Load Balancer"
+  type = map(object({
+    name                           = string
+    protocol                       = string
+    frontend_port                  = number
+    backend_port                   = number
+    frontend_ip_configuration_name = string
+    backend_address_pool_keys      = list(string)
+    probe_key                      = optional(string)
+    enable_floating_ip             = optional(bool)
+    enable_tcp_reset               = optional(bool)
+    disable_outbound_snat          = optional(bool)
+    idle_timeout_in_minutes        = optional(number)
+    load_distribution              = optional(string)
+  }))
+  default = {}
+}
+
+variable "nat_rules" {
+  description = "Map of inbound NAT rules for the Load Balancer"
+  type = map(object({
+    name                           = string
+    protocol                       = string
+    frontend_port                  = number
+    backend_port                   = number
+    frontend_ip_configuration_name = string
+    idle_timeout_in_minutes        = optional(number)
+    enable_floating_ip             = optional(bool)
+    enable_tcp_reset               = optional(bool)
+    backend_address_pool_key       = optional(string)
+  }))
+  default = {}
+}
+
+variable "nat_pools" {
+  description = "Map of NAT pools for the Load Balancer"
+  type = map(object({
+    name                           = string
+    protocol                       = string
+    frontend_port_start            = number
+    frontend_port_end              = number
+    backend_port                   = number
+    frontend_ip_configuration_name = string
+    idle_timeout_in_minutes        = optional(number)
+    floating_ip_enabled            = optional(bool)
+    tcp_reset_enabled              = optional(bool)
+  }))
+  default = {}
+}
+
+variable "outbound_rules" {
+  description = "Map of outbound rules for the Load Balancer (Standard SKU only)"
+  type = map(object({
+    name                            = string
+    protocol                        = string
+    backend_address_pool_key        = string
+    frontend_ip_configuration_names = list(string)
+    allocated_outbound_ports        = optional(number)
+    idle_timeout_in_minutes         = optional(number)
+    enable_tcp_reset                = optional(bool)
+  }))
+  default = {}
+}
+
+# CloudPosse Label Module Variables
+variable "namespace" {
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+  type        = string
+  default     = null
+}
+
+variable "tenant" {
+  description = "ID element. Usually used to indicate the tenant identifier"
+  type        = string
+  default     = null
+}
+
+variable "environment" {
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+  type        = string
+  default     = null
+}
+
+variable "stage" {
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'"
+  type        = string
+  default     = null
+}
+
+variable "attributes" {
+  description = "ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`, in the order they appear in the list"
+  type        = list(string)
+  default     = []
+}
+
+variable "delimiter" {
+  description = "Delimiter to be used between ID elements. Defaults to `-` (hyphen)"
+  type        = string
+  default     = "-"
+}
+
+variable "tags" {
+  description = "Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`) to add to the resource tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "regex_replace_chars" {
+  description = "Terraform regular expression (regex) string. Characters matching the regex will be removed from the ID elements. If not set, `\"/[^a-zA-Z0-9-]/\"` is used to remove all characters other than hyphens, letters and digits"
+  type        = string
+  default     = null
+}
+
+variable "label_order" {
+  description = "The order in which the labels (ID elements) appear in the `id`. Defaults to [\"namespace\", \"environment\", \"stage\", \"name\", \"attributes\"]. You can omit any of the 6 labels (\"tenant\" is the 6th), but at least one must be present"
+  type        = list(string)
+  default     = null
+}
+
+variable "label_key_case" {
+  description = "Controls the letter case of the `tags` keys (label names) for tags generated by this module. Does not affect keys of tags passed in via the `tags` input. Possible values: `lower`, `title`, `upper`. Default value: `title`"
+  type        = string
+  default     = null
+}
+
+variable "label_value_case" {
+  description = "Controls the letter case of ID elements (labels) as included in `id`, set as tag values, and output by this module individually. Does not affect values of tags passed in via the `tags` input. Possible values: `lower`, `title`, `upper` and `none` (no transformation). Set this to `title` and set `delimiter` to `\"\"` to yield Pascal Case IDs. Default value: `lower`"
+  type        = string
+  default     = null
+}
+
+variable "id_length_limit" {
+  description = "Limit `id` to this many characters (minimum 6). Set to `0` for unlimited length. Set to `null` for keep the existing setting, which defaults to `0`. Does not affect `id_full`"
+  type        = number
+  default     = null
+}


### PR DESCRIPTION
Implements a comprehensive Azure Load Balancer module with support for:
- Multiple SKU types (Basic, Standard, Gateway)
- Frontend IP configurations (public and private)
- Backend address pools with tunnel interface support
- Health probes (TCP, HTTP, HTTPS)
- Load balancing rules with customizable distribution
- Inbound NAT rules and NAT pools
- Outbound rules for Standard SKU
- Zone redundancy support
- CloudPosse label integration for consistent naming

Based on azurerm provider version 4.20.0 following repository standards. All files formatted with terraform fmt -recursive.

## Summary
<!-- Brief description of what this PR accomplishes -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code cleanup/refactoring
- [ ] 🚀 Performance improvement

## Changes Made
<!-- List the key changes in this PR -->
- 
- 

## Components/Stacks Affected
<!-- List any Atmos components or stacks modified -->
- 

## Notes
<!-- Any additional context, considerations, or follow-up items -->

---
*Atmos validation and testing will run automatically via GitHub Actions*
