### PR TITLE
Add Azure Front Door component with Terraform

### DIFF
--- a/atmos/components/terraform/modules/azure-frontdoor/README.md
+++ b/atmos/components/terraform/modules/azure-frontdoor/README.md
@@ -1,0 +1,349 @@
+# Azure Front Door Component
+
+This Terraform component provisions an Azure Front Door (Standard or Premium) with support for endpoints, origin groups, origins, routes, rules, custom domains, and security policies.
+
+## Features
+
+- **Azure Front Door Profile**: Standard or Premium SKU
+- **Endpoints**: Multiple Front Door endpoints with custom configuration
+- **Origin Groups**: Configure origin groups with load balancing and health probes
+- **Origins**: Support for public and private origins with Private Link
+- **Routes**: Path-based routing with caching and custom domain support
+- **Rule Sets & Rules**: Advanced traffic routing and manipulation
+- **Custom Domains**: HTTPS support with managed or custom certificates
+- **Security Policies**: WAF integration (Premium SKU only)
+- **Health Probes**: Configurable health monitoring for origins
+- **Caching**: Query string caching, compression, and cache behavior
+- **SSL/TLS**: Configurable minimum TLS version and certificate management
+- **Private Link**: Secure connectivity to private origin services
+
+## Usage
+
+### Basic Example
+
+```yaml
+components:
+  terraform:
+    azure-frontdoor:
+      vars:
+        enabled: true
+        namespace: "myorg"
+        environment: "eus"
+        stage: "dev"
+        name: "cdn"
+        resource_group_name: "my-resource-group"
+        sku_name: "Standard_AzureFrontDoor"
+
+        endpoints:
+          main:
+            name: "main-endpoint"
+            enabled: true
+
+        origin_groups:
+          default:
+            name: "default-origin-group"
+            load_balancing:
+              sample_size: 4
+              successful_samples_required: 3
+            health_probe:
+              protocol: "Https"
+              interval_in_seconds: 100
+              path: "/health"
+
+        origins:
+          web:
+            name: "web-origin"
+            origin_group_key: "default"
+            host_name: "myapp.azurewebsites.net"
+            https_port: 443
+            http_port: 80
+
+        routes:
+          default:
+            name: "default-route"
+            endpoint_key: "main"
+            origin_group_key: "default"
+            origin_keys: ["web"]
+            patterns_to_match: ["/*"]
+            supported_protocols: ["Http", "Https"]
+            https_redirect_enabled: true
+            cache:
+              query_string_caching_behavior: "IgnoreQueryString"
+              compression_enabled: true
+```
+
+### Advanced Example with Custom Domains and Rules
+
+```yaml
+components:
+  terraform:
+    azure-frontdoor-premium:
+      metadata:
+        component: azure-frontdoor
+      vars:
+        enabled: true
+        namespace: "myorg"
+        environment: "eus"
+        stage: "prod"
+        name: "cdn"
+        resource_group_name: "my-prod-rg"
+        sku_name: "Premium_AzureFrontDoor"
+        response_timeout_seconds: 120
+
+        endpoints:
+          main:
+            name: "main-endpoint"
+            enabled: true
+          api:
+            name: "api-endpoint"
+            enabled: true
+
+        origin_groups:
+          web:
+            name: "web-origin-group"
+            session_affinity_enabled: true
+            load_balancing:
+              sample_size: 4
+              successful_samples_required: 3
+              additional_latency_in_milliseconds: 50
+            health_probe:
+              protocol: "Https"
+              interval_in_seconds: 120
+              request_type: "HEAD"
+              path: "/health"
+
+          api:
+            name: "api-origin-group"
+            load_balancing:
+              sample_size: 4
+              successful_samples_required: 2
+            health_probe:
+              protocol: "Https"
+              interval_in_seconds: 60
+              path: "/api/health"
+
+        origins:
+          web-primary:
+            name: "web-primary"
+            origin_group_key: "web"
+            host_name: "web-primary.azurewebsites.net"
+            priority: 1
+            weight: 1000
+
+          web-secondary:
+            name: "web-secondary"
+            origin_group_key: "web"
+            host_name: "web-secondary.azurewebsites.net"
+            priority: 2
+            weight: 500
+
+          api-origin:
+            name: "api-origin"
+            origin_group_key: "api"
+            host_name: "api.internal.example.com"
+            private_link:
+              location: "eastus"
+              private_link_target_id: "/subscriptions/.../privateLinkServices/..."
+              request_message: "Please approve this connection"
+
+        custom_domains:
+          www:
+            name: "www-domain"
+            host_name: "www.example.com"
+            tls:
+              certificate_type: "ManagedCertificate"
+              minimum_tls_version: "TLS12"
+
+          api:
+            name: "api-domain"
+            host_name: "api.example.com"
+            tls:
+              certificate_type: "ManagedCertificate"
+              minimum_tls_version: "TLS12"
+
+        routes:
+          web:
+            name: "web-route"
+            endpoint_key: "main"
+            origin_group_key: "web"
+            origin_keys: ["web-primary", "web-secondary"]
+            patterns_to_match: ["/*"]
+            supported_protocols: ["Http", "Https"]
+            https_redirect_enabled: true
+            custom_domain_keys: ["www"]
+            rule_set_keys: ["security"]
+            cache:
+              query_string_caching_behavior: "IgnoreQueryString"
+              compression_enabled: true
+              content_types_to_compress: [
+                "text/html",
+                "text/css",
+                "application/javascript",
+                "application/json"
+              ]
+
+          api:
+            name: "api-route"
+            endpoint_key: "api"
+            origin_group_key: "api"
+            origin_keys: ["api-origin"]
+            patterns_to_match: ["/api/*"]
+            supported_protocols: ["Https"]
+            custom_domain_keys: ["api"]
+            cache:
+              query_string_caching_behavior: "UseQueryString"
+              compression_enabled: false
+
+        rule_sets:
+          security:
+            name: "security-rules"
+
+        rules:
+          add-security-headers:
+            name: "add-security-headers"
+            rule_set_key: "security"
+            order: 1
+            actions:
+              response_header_action:
+                - header_action: "Append"
+                  header_name: "X-Content-Type-Options"
+                  value: "nosniff"
+                - header_action: "Append"
+                  header_name: "X-Frame-Options"
+                  value: "SAMEORIGIN"
+                - header_action: "Append"
+                  header_name: "Strict-Transport-Security"
+                  value: "max-age=31536000"
+
+        security_policies:
+          main:
+            name: "main-waf-policy"
+            firewall_policy_id: "/subscriptions/.../providers/Microsoft.Network/FrontDoorWebApplicationFirewallPolicies/..."
+            domain_keys: ["www", "api"]
+            patterns_to_match: ["/*"]
+```
+
+### Private Link Origin Example
+
+```yaml
+origins:
+  storage:
+    name: "storage-origin"
+    origin_group_key: "storage"
+    host_name: "mystorageaccount.blob.core.windows.net"
+    private_link:
+      location: "eastus"
+      private_link_target_id: "/subscriptions/.../resourceGroups/.../providers/Microsoft.Storage/storageAccounts/mystorageaccount"
+      target_type: "blob"
+      request_message: "Front Door connection request"
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.9.0 |
+| azurerm | 4.20.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| azurerm | 4.20.0 |
+
+## Inputs
+
+### Core Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| resource_group_name | Name of the resource group where the Front Door will be created | `string` | n/a | yes |
+| custom_name | Custom name for the Front Door Profile (overrides label module generated name) | `string` | `null` | no |
+| sku_name | SKU name for the Front Door Profile (Standard_AzureFrontDoor or Premium_AzureFrontDoor) | `string` | `"Standard_AzureFrontDoor"` | no |
+| response_timeout_seconds | Response timeout in seconds (16-240) | `number` | `120` | no |
+
+### Front Door Configuration
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| endpoints | Map of Front Door endpoints to create | `map(object)` | `{}` | no |
+| origin_groups | Map of origin groups for the Front Door | `map(object)` | `{}` | no |
+| origins | Map of origins for the Front Door origin groups | `map(object)` | `{}` | no |
+| routes | Map of routes for the Front Door | `map(object)` | `{}` | no |
+| rule_sets | Map of rule sets for the Front Door | `map(object)` | `{}` | no |
+| rules | Map of rules for the Front Door rule sets | `map(object)` | `{}` | no |
+| custom_domains | Map of custom domains for the Front Door | `map(object)` | `{}` | no |
+| security_policies | Map of security policies for the Front Door (Premium SKU only) | `map(object)` | `{}` | no |
+
+### Label Module Variables
+
+Standard Cloud Posse label module variables are supported:
+- `namespace`
+- `tenant`
+- `environment`
+- `stage`
+- `name`
+- `attributes`
+- `tags`
+- `delimiter`
+- `label_order`
+- `regex_replace_chars`
+- `id_length_limit`
+- `label_key_case`
+- `label_value_case`
+- `context`
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| id | The ID of the Front Door Profile |
+| name | The name of the Front Door Profile |
+| resource_group_name | The name of the resource group |
+| sku_name | The SKU name of the Front Door Profile |
+| resource_guid | The resource GUID of the Front Door Profile |
+| endpoints | Map of Front Door endpoints |
+| endpoint_host_names | Map of endpoint keys to their host names |
+| origin_groups | Map of Front Door origin groups |
+| origins | Map of Front Door origins |
+| routes | Map of Front Door routes |
+| rule_sets | Map of Front Door rule sets |
+| rules | Map of Front Door rules |
+| custom_domains | Map of Front Door custom domains |
+| security_policies | Map of Front Door security policies |
+| tags | Tags applied to the Front Door Profile |
+| context | Context from the label module |
+
+## SKU Differences
+
+### Standard SKU
+- Basic WAF capabilities
+- HTTP/HTTPS load balancing
+- SSL offload
+- Custom domains with managed certificates
+- Caching and compression
+- Rules engine
+- Analytics and logs
+
+### Premium SKU
+- All Standard SKU features
+- Advanced WAF with managed rules and bot protection
+- Private Link support to origin services
+- Enhanced analytics and diagnostics
+- Increased performance limits
+
+## Notes
+
+- Front Door endpoint names must be globally unique
+- Custom domains require DNS validation before use
+- Private Link requires Premium SKU
+- Security policies (WAF) require Premium SKU for advanced features
+- Health probe intervals should be balanced between responsiveness and origin load
+- SSL/TLS certificates can be managed by Azure or customer-provided
+
+## References
+
+- [Azure Front Door Documentation](https://docs.microsoft.com/en-us/azure/frontdoor/)
+- [Terraform azurerm_cdn_frontdoor_profile](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile)
+- [Cloud Posse Label Module](https://github.com/cloudposse/terraform-null-label)

--- a/atmos/components/terraform/modules/azure-frontdoor/main.tf
+++ b/atmos/components/terraform/modules/azure-frontdoor/main.tf
@@ -1,0 +1,419 @@
+module "label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  attributes          = var.attributes
+  delimiter           = var.delimiter
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  regex_replace_chars = var.regex_replace_chars
+  label_order         = var.label_order
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  context             = var.context
+}
+
+locals {
+  frontdoor_profile_name = var.custom_name != null ? var.custom_name : module.label.id
+}
+
+resource "azurerm_cdn_frontdoor_profile" "this" {
+  count = var.enabled ? 1 : 0
+
+  name                     = local.frontdoor_profile_name
+  resource_group_name      = var.resource_group_name
+  sku_name                 = var.sku_name
+  response_timeout_seconds = var.response_timeout_seconds
+  tags                     = module.label.tags
+}
+
+resource "azurerm_cdn_frontdoor_endpoint" "this" {
+  for_each = var.enabled ? var.endpoints : {}
+
+  name                     = each.value.name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.this[0].id
+  enabled                  = each.value.enabled
+  tags                     = merge(module.label.tags, each.value.tags)
+}
+
+resource "azurerm_cdn_frontdoor_origin_group" "this" {
+  for_each = var.enabled ? var.origin_groups : {}
+
+  name                     = each.value.name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.this[0].id
+  session_affinity_enabled = each.value.session_affinity_enabled
+
+  load_balancing {
+    sample_size                        = each.value.load_balancing.sample_size
+    successful_samples_required        = each.value.load_balancing.successful_samples_required
+    additional_latency_in_milliseconds = each.value.load_balancing.additional_latency_in_milliseconds
+  }
+
+  dynamic "health_probe" {
+    for_each = each.value.health_probe != null ? [each.value.health_probe] : []
+    content {
+      protocol            = health_probe.value.protocol
+      interval_in_seconds = health_probe.value.interval_in_seconds
+      request_type        = health_probe.value.request_type
+      path                = health_probe.value.path
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_origin" "this" {
+  for_each = var.enabled ? var.origins : {}
+
+  name                           = each.value.name
+  cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.this[each.value.origin_group_key].id
+  enabled                        = each.value.enabled
+  certificate_name_check_enabled = each.value.certificate_name_check_enabled
+  host_name                      = each.value.host_name
+  http_port                      = each.value.http_port
+  https_port                     = each.value.https_port
+  origin_host_header             = each.value.origin_host_header
+  priority                       = each.value.priority
+  weight                         = each.value.weight
+
+  dynamic "private_link" {
+    for_each = each.value.private_link != null ? [each.value.private_link] : []
+    content {
+      request_message        = private_link.value.request_message
+      target_type            = private_link.value.target_type
+      location               = private_link.value.location
+      private_link_target_id = private_link.value.private_link_target_id
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_route" "this" {
+  for_each = var.enabled ? var.routes : {}
+
+  name                            = each.value.name
+  cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.this[each.value.endpoint_key].id
+  cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.this[each.value.origin_group_key].id
+  cdn_frontdoor_origin_ids        = [for origin_key in each.value.origin_keys : azurerm_cdn_frontdoor_origin.this[origin_key].id]
+  enabled                         = each.value.enabled
+  forwarding_protocol             = each.value.forwarding_protocol
+  https_redirect_enabled          = each.value.https_redirect_enabled
+  patterns_to_match               = each.value.patterns_to_match
+  supported_protocols             = each.value.supported_protocols
+  cdn_frontdoor_custom_domain_ids = each.value.custom_domain_keys != null ? [for domain_key in each.value.custom_domain_keys : azurerm_cdn_frontdoor_custom_domain.this[domain_key].id] : []
+  link_to_default_domain          = each.value.link_to_default_domain
+  cdn_frontdoor_rule_set_ids      = each.value.rule_set_keys != null ? [for rule_set_key in each.value.rule_set_keys : azurerm_cdn_frontdoor_rule_set.this[rule_set_key].id] : []
+
+  dynamic "cache" {
+    for_each = each.value.cache != null ? [each.value.cache] : []
+    content {
+      query_string_caching_behavior = cache.value.query_string_caching_behavior
+      query_strings                 = cache.value.query_strings
+      compression_enabled           = cache.value.compression_enabled
+      content_types_to_compress     = cache.value.content_types_to_compress
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "this" {
+  for_each = var.enabled ? var.rule_sets : {}
+
+  name                     = each.value.name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.this[0].id
+}
+
+resource "azurerm_cdn_frontdoor_rule" "this" {
+  for_each = var.enabled ? var.rules : {}
+
+  name                      = each.value.name
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.this[each.value.rule_set_key].id
+  order                     = each.value.order
+  behavior_on_match         = each.value.behavior_on_match
+
+  actions {
+    dynamic "route_configuration_override_action" {
+      for_each = each.value.actions.route_configuration_override_action != null ? [each.value.actions.route_configuration_override_action] : []
+      content {
+        cache_duration                = route_configuration_override_action.value.cache_duration
+        cdn_frontdoor_origin_group_id = route_configuration_override_action.value.origin_group_key != null ? azurerm_cdn_frontdoor_origin_group.this[route_configuration_override_action.value.origin_group_key].id : null
+        forwarding_protocol           = route_configuration_override_action.value.forwarding_protocol
+        query_string_caching_behavior = route_configuration_override_action.value.query_string_caching_behavior
+        query_string_parameters       = route_configuration_override_action.value.query_string_parameters
+        compression_enabled           = route_configuration_override_action.value.compression_enabled
+        cache_behavior                = route_configuration_override_action.value.cache_behavior
+      }
+    }
+
+    dynamic "url_redirect_action" {
+      for_each = each.value.actions.url_redirect_action != null ? [each.value.actions.url_redirect_action] : []
+      content {
+        redirect_type        = url_redirect_action.value.redirect_type
+        redirect_protocol    = url_redirect_action.value.redirect_protocol
+        query_string         = url_redirect_action.value.query_string
+        destination_path     = url_redirect_action.value.destination_path
+        destination_hostname = url_redirect_action.value.destination_hostname
+        destination_fragment = url_redirect_action.value.destination_fragment
+      }
+    }
+
+    dynamic "url_rewrite_action" {
+      for_each = each.value.actions.url_rewrite_action != null ? [each.value.actions.url_rewrite_action] : []
+      content {
+        source_pattern          = url_rewrite_action.value.source_pattern
+        destination             = url_rewrite_action.value.destination
+        preserve_unmatched_path = url_rewrite_action.value.preserve_unmatched_path
+      }
+    }
+
+    dynamic "request_header_action" {
+      for_each = each.value.actions.request_header_action != null ? each.value.actions.request_header_action : []
+      content {
+        header_action = request_header_action.value.header_action
+        header_name   = request_header_action.value.header_name
+        value         = request_header_action.value.value
+      }
+    }
+
+    dynamic "response_header_action" {
+      for_each = each.value.actions.response_header_action != null ? each.value.actions.response_header_action : []
+      content {
+        header_action = response_header_action.value.header_action
+        header_name   = response_header_action.value.header_name
+        value         = response_header_action.value.value
+      }
+    }
+  }
+
+  dynamic "conditions" {
+    for_each = each.value.conditions != null ? [each.value.conditions] : []
+    content {
+      dynamic "remote_address_condition" {
+        for_each = conditions.value.remote_address_condition != null ? [conditions.value.remote_address_condition] : []
+        content {
+          operator         = remote_address_condition.value.operator
+          negate_condition = remote_address_condition.value.negate_condition
+          match_values     = remote_address_condition.value.match_values
+        }
+      }
+
+      dynamic "request_method_condition" {
+        for_each = conditions.value.request_method_condition != null ? [conditions.value.request_method_condition] : []
+        content {
+          operator         = request_method_condition.value.operator
+          negate_condition = request_method_condition.value.negate_condition
+          match_values     = request_method_condition.value.match_values
+        }
+      }
+
+      dynamic "query_string_condition" {
+        for_each = conditions.value.query_string_condition != null ? [conditions.value.query_string_condition] : []
+        content {
+          operator         = query_string_condition.value.operator
+          negate_condition = query_string_condition.value.negate_condition
+          match_values     = query_string_condition.value.match_values
+          transforms       = query_string_condition.value.transforms
+        }
+      }
+
+      dynamic "post_args_condition" {
+        for_each = conditions.value.post_args_condition != null ? [conditions.value.post_args_condition] : []
+        content {
+          post_args_name   = post_args_condition.value.post_args_name
+          operator         = post_args_condition.value.operator
+          negate_condition = post_args_condition.value.negate_condition
+          match_values     = post_args_condition.value.match_values
+          transforms       = post_args_condition.value.transforms
+        }
+      }
+
+      dynamic "request_uri_condition" {
+        for_each = conditions.value.request_uri_condition != null ? [conditions.value.request_uri_condition] : []
+        content {
+          operator         = request_uri_condition.value.operator
+          negate_condition = request_uri_condition.value.negate_condition
+          match_values     = request_uri_condition.value.match_values
+          transforms       = request_uri_condition.value.transforms
+        }
+      }
+
+      dynamic "request_header_condition" {
+        for_each = conditions.value.request_header_condition != null ? [conditions.value.request_header_condition] : []
+        content {
+          header_name      = request_header_condition.value.header_name
+          operator         = request_header_condition.value.operator
+          negate_condition = request_header_condition.value.negate_condition
+          match_values     = request_header_condition.value.match_values
+          transforms       = request_header_condition.value.transforms
+        }
+      }
+
+      dynamic "request_body_condition" {
+        for_each = conditions.value.request_body_condition != null ? [conditions.value.request_body_condition] : []
+        content {
+          operator         = request_body_condition.value.operator
+          negate_condition = request_body_condition.value.negate_condition
+          match_values     = request_body_condition.value.match_values
+          transforms       = request_body_condition.value.transforms
+        }
+      }
+
+      dynamic "request_scheme_condition" {
+        for_each = conditions.value.request_scheme_condition != null ? [conditions.value.request_scheme_condition] : []
+        content {
+          operator         = request_scheme_condition.value.operator
+          negate_condition = request_scheme_condition.value.negate_condition
+          match_values     = request_scheme_condition.value.match_values
+        }
+      }
+
+      dynamic "url_path_condition" {
+        for_each = conditions.value.url_path_condition != null ? [conditions.value.url_path_condition] : []
+        content {
+          operator         = url_path_condition.value.operator
+          negate_condition = url_path_condition.value.negate_condition
+          match_values     = url_path_condition.value.match_values
+          transforms       = url_path_condition.value.transforms
+        }
+      }
+
+      dynamic "url_file_extension_condition" {
+        for_each = conditions.value.url_file_extension_condition != null ? [conditions.value.url_file_extension_condition] : []
+        content {
+          operator         = url_file_extension_condition.value.operator
+          negate_condition = url_file_extension_condition.value.negate_condition
+          match_values     = url_file_extension_condition.value.match_values
+          transforms       = url_file_extension_condition.value.transforms
+        }
+      }
+
+      dynamic "url_filename_condition" {
+        for_each = conditions.value.url_filename_condition != null ? [conditions.value.url_filename_condition] : []
+        content {
+          operator         = url_filename_condition.value.operator
+          negate_condition = url_filename_condition.value.negate_condition
+          match_values     = url_filename_condition.value.match_values
+          transforms       = url_filename_condition.value.transforms
+        }
+      }
+
+      dynamic "http_version_condition" {
+        for_each = conditions.value.http_version_condition != null ? [conditions.value.http_version_condition] : []
+        content {
+          operator         = http_version_condition.value.operator
+          negate_condition = http_version_condition.value.negate_condition
+          match_values     = http_version_condition.value.match_values
+        }
+      }
+
+      dynamic "cookies_condition" {
+        for_each = conditions.value.cookies_condition != null ? [conditions.value.cookies_condition] : []
+        content {
+          cookie_name      = cookies_condition.value.cookie_name
+          operator         = cookies_condition.value.operator
+          negate_condition = cookies_condition.value.negate_condition
+          match_values     = cookies_condition.value.match_values
+          transforms       = cookies_condition.value.transforms
+        }
+      }
+
+      dynamic "is_device_condition" {
+        for_each = conditions.value.is_device_condition != null ? [conditions.value.is_device_condition] : []
+        content {
+          operator         = is_device_condition.value.operator
+          negate_condition = is_device_condition.value.negate_condition
+          match_values     = is_device_condition.value.match_values
+        }
+      }
+
+      dynamic "socket_address_condition" {
+        for_each = conditions.value.socket_address_condition != null ? [conditions.value.socket_address_condition] : []
+        content {
+          operator         = socket_address_condition.value.operator
+          negate_condition = socket_address_condition.value.negate_condition
+          match_values     = socket_address_condition.value.match_values
+        }
+      }
+
+      dynamic "client_port_condition" {
+        for_each = conditions.value.client_port_condition != null ? [conditions.value.client_port_condition] : []
+        content {
+          operator         = client_port_condition.value.operator
+          negate_condition = client_port_condition.value.negate_condition
+          match_values     = client_port_condition.value.match_values
+        }
+      }
+
+      dynamic "server_port_condition" {
+        for_each = conditions.value.server_port_condition != null ? [conditions.value.server_port_condition] : []
+        content {
+          operator         = server_port_condition.value.operator
+          negate_condition = server_port_condition.value.negate_condition
+          match_values     = server_port_condition.value.match_values
+        }
+      }
+
+      dynamic "host_name_condition" {
+        for_each = conditions.value.host_name_condition != null ? [conditions.value.host_name_condition] : []
+        content {
+          operator         = host_name_condition.value.operator
+          negate_condition = host_name_condition.value.negate_condition
+          match_values     = host_name_condition.value.match_values
+          transforms       = host_name_condition.value.transforms
+        }
+      }
+
+      dynamic "ssl_protocol_condition" {
+        for_each = conditions.value.ssl_protocol_condition != null ? [conditions.value.ssl_protocol_condition] : []
+        content {
+          operator         = ssl_protocol_condition.value.operator
+          negate_condition = ssl_protocol_condition.value.negate_condition
+          match_values     = ssl_protocol_condition.value.match_values
+        }
+      }
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain" "this" {
+  for_each = var.enabled ? var.custom_domains : {}
+
+  name                     = each.value.name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.this[0].id
+  dns_zone_id              = each.value.dns_zone_id
+  host_name                = each.value.host_name
+
+  dynamic "tls" {
+    for_each = each.value.tls != null ? [each.value.tls] : []
+    content {
+      certificate_type        = tls.value.certificate_type
+      minimum_tls_version     = tls.value.minimum_tls_version
+      cdn_frontdoor_secret_id = tls.value.cdn_frontdoor_secret_id
+    }
+  }
+}
+
+resource "azurerm_cdn_frontdoor_security_policy" "this" {
+  for_each = var.enabled ? var.security_policies : {}
+
+  name                     = each.value.name
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.this[0].id
+
+  security_policies {
+    firewall {
+      cdn_frontdoor_firewall_policy_id = each.value.firewall_policy_id
+      association {
+        dynamic "domain" {
+          for_each = each.value.domain_keys != null ? each.value.domain_keys : []
+          content {
+            cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.this[domain.value].id
+          }
+        }
+        patterns_to_match = each.value.patterns_to_match
+      }
+    }
+  }
+}

--- a/atmos/components/terraform/modules/azure-frontdoor/outputs.tf
+++ b/atmos/components/terraform/modules/azure-frontdoor/outputs.tf
@@ -1,0 +1,111 @@
+output "id" {
+  description = "The ID of the Front Door Profile"
+  value       = var.enabled ? azurerm_cdn_frontdoor_profile.this[0].id : null
+}
+
+output "name" {
+  description = "The name of the Front Door Profile"
+  value       = var.enabled ? azurerm_cdn_frontdoor_profile.this[0].name : null
+}
+
+output "resource_group_name" {
+  description = "The name of the resource group"
+  value       = var.enabled ? azurerm_cdn_frontdoor_profile.this[0].resource_group_name : null
+}
+
+output "sku_name" {
+  description = "The SKU name of the Front Door Profile"
+  value       = var.enabled ? azurerm_cdn_frontdoor_profile.this[0].sku_name : null
+}
+
+output "resource_guid" {
+  description = "The resource GUID of the Front Door Profile"
+  value       = var.enabled ? azurerm_cdn_frontdoor_profile.this[0].resource_guid : null
+}
+
+output "endpoints" {
+  description = "Map of Front Door endpoints"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_endpoint.this : k => {
+    id        = v.id
+    name      = v.name
+    host_name = v.host_name
+    enabled   = v.enabled
+  } } : {}
+}
+
+output "endpoint_host_names" {
+  description = "Map of endpoint keys to their host names"
+  value       = var.enabled ? { for k, v in azurerm_cdn_frontdoor_endpoint.this : k => v.host_name } : {}
+}
+
+output "origin_groups" {
+  description = "Map of Front Door origin groups"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_origin_group.this : k => {
+    id   = v.id
+    name = v.name
+  } } : {}
+}
+
+output "origins" {
+  description = "Map of Front Door origins"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_origin.this : k => {
+    id        = v.id
+    name      = v.name
+    host_name = v.host_name
+  } } : {}
+}
+
+output "routes" {
+  description = "Map of Front Door routes"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_route.this : k => {
+    id                  = v.id
+    name                = v.name
+    enabled             = v.enabled
+    patterns_to_match   = v.patterns_to_match
+    supported_protocols = v.supported_protocols
+  } } : {}
+}
+
+output "rule_sets" {
+  description = "Map of Front Door rule sets"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_rule_set.this : k => {
+    id   = v.id
+    name = v.name
+  } } : {}
+}
+
+output "rules" {
+  description = "Map of Front Door rules"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_rule.this : k => {
+    id    = v.id
+    name  = v.name
+    order = v.order
+  } } : {}
+}
+
+output "custom_domains" {
+  description = "Map of Front Door custom domains"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_custom_domain.this : k => {
+    id        = v.id
+    name      = v.name
+    host_name = v.host_name
+  } } : {}
+}
+
+output "security_policies" {
+  description = "Map of Front Door security policies"
+  value = var.enabled ? { for k, v in azurerm_cdn_frontdoor_security_policy.this : k => {
+    id   = v.id
+    name = v.name
+  } } : {}
+}
+
+output "tags" {
+  description = "Tags applied to the Front Door Profile"
+  value       = module.label.tags
+}
+
+output "context" {
+  description = "Context from the label module"
+  value       = module.label.context
+}

--- a/atmos/components/terraform/modules/azure-frontdoor/providers.tf
+++ b/atmos/components/terraform/modules/azure-frontdoor/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "4.20.0"
+    }
+  }
+}

--- a/atmos/components/terraform/modules/azure-frontdoor/variables.tf
+++ b/atmos/components/terraform/modules/azure-frontdoor/variables.tf
@@ -1,0 +1,419 @@
+variable "enabled" {
+  description = "Set to false to prevent the module from creating any resources"
+  type        = bool
+  default     = true
+}
+
+# ==============================================================================
+# Cloud Posse Label Module Variables
+# ==============================================================================
+
+variable "namespace" {
+  description = "Namespace, which could be your organization name or abbreviation"
+  type        = string
+  default     = null
+}
+
+variable "tenant" {
+  description = "Account Name or unique account unique id e.g., apps or management or aws account id"
+  type        = string
+  default     = null
+}
+
+variable "environment" {
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+  type        = string
+  default     = null
+}
+
+variable "stage" {
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+  type        = string
+  default     = null
+}
+
+variable "name" {
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+  type        = string
+  default     = null
+}
+
+variable "attributes" {
+  description = "Additional attributes (e.g. `1`)"
+  type        = list(string)
+  default     = []
+}
+
+variable "delimiter" {
+  description = "Delimiter to be used between namespace, environment, stage, name and attributes"
+  type        = string
+  default     = "-"
+}
+
+variable "tags" {
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "additional_tag_map" {
+  description = "Additional tags for appending to tags_as_list_of_maps"
+  type        = map(string)
+  default     = {}
+}
+
+variable "regex_replace_chars" {
+  description = "Regex to replace chars with empty string in namespace, environment, stage and name"
+  type        = string
+  default     = "/[^a-zA-Z0-9-]/"
+}
+
+variable "label_order" {
+  description = "The naming order of the id output and Name tag"
+  type        = list(string)
+  default     = []
+}
+
+variable "id_length_limit" {
+  description = "Limit `id` to this many characters. Set to `0` for unlimited length"
+  type        = number
+  default     = 0
+}
+
+variable "label_key_case" {
+  description = "The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`"
+  type        = string
+  default     = "lower"
+}
+
+variable "label_value_case" {
+  description = "The letter case of output label values (also used in `tags` and `id`)"
+  type        = string
+  default     = "lower"
+}
+
+variable "context" {
+  description = "Single object for setting entire context at once"
+  type        = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+  }
+}
+
+# ==============================================================================
+# Azure Front Door Variables
+# ==============================================================================
+
+variable "resource_group_name" {
+  description = "Name of the resource group where the Front Door will be created"
+  type        = string
+}
+
+variable "custom_name" {
+  description = "Custom name for the Front Door Profile (overrides label module generated name)"
+  type        = string
+  default     = null
+}
+
+variable "sku_name" {
+  description = "SKU name for the Front Door Profile. Possible values include: Standard_AzureFrontDoor, Premium_AzureFrontDoor"
+  type        = string
+  default     = "Standard_AzureFrontDoor"
+
+  validation {
+    condition     = contains(["Standard_AzureFrontDoor", "Premium_AzureFrontDoor"], var.sku_name)
+    error_message = "SKU name must be either Standard_AzureFrontDoor or Premium_AzureFrontDoor"
+  }
+}
+
+variable "response_timeout_seconds" {
+  description = "Response timeout in seconds. Possible values are between 16 and 240 seconds"
+  type        = number
+  default     = 120
+
+  validation {
+    condition     = var.response_timeout_seconds >= 16 && var.response_timeout_seconds <= 240
+    error_message = "Response timeout must be between 16 and 240 seconds"
+  }
+}
+
+variable "endpoints" {
+  description = "Map of Front Door endpoints to create"
+  type = map(object({
+    name    = string
+    enabled = optional(bool, true)
+    tags    = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "origin_groups" {
+  description = "Map of origin groups for the Front Door"
+  type = map(object({
+    name                     = string
+    session_affinity_enabled = optional(bool, false)
+    load_balancing = object({
+      sample_size                        = optional(number, 4)
+      successful_samples_required        = optional(number, 3)
+      additional_latency_in_milliseconds = optional(number, 50)
+    })
+    health_probe = optional(object({
+      protocol            = string # Http or Https
+      interval_in_seconds = number
+      request_type        = optional(string, "HEAD") # HEAD or GET
+      path                = optional(string, "/")
+    }))
+  }))
+  default = {}
+}
+
+variable "origins" {
+  description = "Map of origins for the Front Door origin groups"
+  type = map(object({
+    name                           = string
+    origin_group_key               = string
+    enabled                        = optional(bool, true)
+    certificate_name_check_enabled = optional(bool, true)
+    host_name                      = string
+    http_port                      = optional(number, 80)
+    https_port                     = optional(number, 443)
+    origin_host_header             = optional(string)
+    priority                       = optional(number, 1)
+    weight                         = optional(number, 1000)
+    private_link = optional(object({
+      request_message        = optional(string)
+      target_type            = optional(string)
+      location               = string
+      private_link_target_id = string
+    }))
+  }))
+  default = {}
+}
+
+variable "routes" {
+  description = "Map of routes for the Front Door"
+  type = map(object({
+    name                   = string
+    endpoint_key           = string
+    origin_group_key       = string
+    origin_keys            = list(string)
+    enabled                = optional(bool, true)
+    forwarding_protocol    = optional(string, "HttpsOnly") # HttpOnly, HttpsOnly, MatchRequest
+    https_redirect_enabled = optional(bool, true)
+    patterns_to_match      = list(string)
+    supported_protocols    = list(string) # Http, Https
+    custom_domain_keys     = optional(list(string))
+    link_to_default_domain = optional(bool, true)
+    rule_set_keys          = optional(list(string))
+    cache = optional(object({
+      query_string_caching_behavior = optional(string, "IgnoreQueryString") # IgnoreQueryString, UseQueryString, IgnoreSpecifiedQueryStrings, IncludeSpecifiedQueryStrings
+      query_strings                 = optional(list(string))
+      compression_enabled           = optional(bool, true)
+      content_types_to_compress     = optional(list(string))
+    }))
+  }))
+  default = {}
+}
+
+variable "rule_sets" {
+  description = "Map of rule sets for the Front Door"
+  type = map(object({
+    name = string
+  }))
+  default = {}
+}
+
+variable "rules" {
+  description = "Map of rules for the Front Door rule sets"
+  type = map(object({
+    name              = string
+    rule_set_key      = string
+    order             = number
+    behavior_on_match = optional(string, "Continue") # Continue or Stop
+    actions = object({
+      route_configuration_override_action = optional(object({
+        cache_duration                = optional(string)
+        origin_group_key              = optional(string)
+        forwarding_protocol           = optional(string) # HttpOnly, HttpsOnly, MatchRequest
+        query_string_caching_behavior = optional(string) # IgnoreQueryString, UseQueryString, IgnoreSpecifiedQueryStrings, IncludeSpecifiedQueryStrings
+        query_string_parameters       = optional(list(string))
+        compression_enabled           = optional(bool)
+        cache_behavior                = optional(string) # HonorOrigin, OverrideAlways, OverrideIfOriginMissing
+      }))
+      url_redirect_action = optional(object({
+        redirect_type        = string                           # Moved, Found, TemporaryRedirect, PermanentRedirect
+        redirect_protocol    = optional(string, "MatchRequest") # MatchRequest, Http, Https
+        query_string         = optional(string)
+        destination_path     = optional(string)
+        destination_hostname = string
+        destination_fragment = optional(string)
+      }))
+      url_rewrite_action = optional(object({
+        source_pattern          = string
+        destination             = string
+        preserve_unmatched_path = optional(bool, false)
+      }))
+      request_header_action = optional(list(object({
+        header_action = string # Append, Overwrite, Delete
+        header_name   = string
+        value         = optional(string)
+      })))
+      response_header_action = optional(list(object({
+        header_action = string # Append, Overwrite, Delete
+        header_name   = string
+        value         = optional(string)
+      })))
+    })
+    conditions = optional(object({
+      remote_address_condition = optional(object({
+        operator         = optional(string, "IPMatch") # IPMatch
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+      }))
+      request_method_condition = optional(object({
+        operator         = optional(string, "Equal")
+        negate_condition = optional(bool, false)
+        match_values     = list(string) # GET, POST, PUT, DELETE, HEAD, OPTIONS, TRACE
+      }))
+      query_string_condition = optional(object({
+        operator         = string # Any, Equal, Contains, BeginsWith, EndsWith, LessThan, LessThanOrEqual, GreaterThan, GreaterThanOrEqual, RegEx
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+        transforms       = optional(list(string)) # Lowercase, Uppercase, Trim, UrlDecode, UrlEncode, RemoveNulls
+      }))
+      post_args_condition = optional(object({
+        post_args_name   = string
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+        transforms       = optional(list(string))
+      }))
+      request_uri_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+        transforms       = optional(list(string))
+      }))
+      request_header_condition = optional(object({
+        header_name      = string
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+        transforms       = optional(list(string))
+      }))
+      request_body_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = list(string)
+        transforms       = optional(list(string))
+      }))
+      request_scheme_condition = optional(object({
+        operator         = optional(string, "Equal")
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string), ["HTTP"]) # HTTP or HTTPS
+      }))
+      url_path_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+        transforms       = optional(list(string))
+      }))
+      url_file_extension_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = list(string)
+        transforms       = optional(list(string))
+      }))
+      url_filename_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = list(string)
+        transforms       = optional(list(string))
+      }))
+      http_version_condition = optional(object({
+        operator         = optional(string, "Equal")
+        negate_condition = optional(bool, false)
+        match_values     = list(string) # 2.0, 1.1, 1.0, 0.9
+      }))
+      cookies_condition = optional(object({
+        cookie_name      = string
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+        transforms       = optional(list(string))
+      }))
+      is_device_condition = optional(object({
+        operator         = optional(string, "Equal")
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string), ["Mobile"]) # Mobile or Desktop
+      }))
+      socket_address_condition = optional(object({
+        operator         = optional(string, "IPMatch")
+        negate_condition = optional(bool, false)
+        match_values     = optional(list(string))
+      }))
+      client_port_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = list(string)
+      }))
+      server_port_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = list(string)
+      }))
+      host_name_condition = optional(object({
+        operator         = string
+        negate_condition = optional(bool, false)
+        match_values     = list(string)
+        transforms       = optional(list(string))
+      }))
+      ssl_protocol_condition = optional(object({
+        operator         = optional(string, "Equal")
+        negate_condition = optional(bool, false)
+        match_values     = list(string) # TLSv1, TLSv1.1, TLSv1.2, TLSv1.3
+      }))
+    }))
+  }))
+  default = {}
+}
+
+variable "custom_domains" {
+  description = "Map of custom domains for the Front Door"
+  type = map(object({
+    name        = string
+    dns_zone_id = optional(string)
+    host_name   = string
+    tls = optional(object({
+      certificate_type        = optional(string, "ManagedCertificate") # ManagedCertificate, CustomerCertificate
+      minimum_tls_version     = optional(string, "TLS12")              # TLS10, TLS12
+      cdn_frontdoor_secret_id = optional(string)
+    }))
+  }))
+  default = {}
+}
+
+variable "security_policies" {
+  description = "Map of security policies for the Front Door (Premium SKU only)"
+  type = map(object({
+    name               = string
+    firewall_policy_id = string
+    domain_keys        = optional(list(string))
+    patterns_to_match  = list(string)
+  }))
+  default = {}
+}

--- a/atmos/stacks/catalog/azure-frontdoor/defaults.yaml
+++ b/atmos/stacks/catalog/azure-frontdoor/defaults.yaml
@@ -1,0 +1,60 @@
+components:
+  terraform:
+    azure-frontdoor:
+      metadata:
+        component: azure-frontdoor
+        type: abstract
+      vars:
+        enabled: true
+        delimiter: ""
+        regex_replace_chars: "/[^a-zA-Z0-9]/"
+        label_order:
+          - namespace
+          - name
+          - environment
+
+        # Default SKU configuration
+        sku_name: "Standard_AzureFrontDoor"
+
+        # Default response timeout
+        response_timeout_seconds: 120
+
+        # Default endpoints configuration
+        endpoints:
+          main:
+            name: "main-endpoint"
+            enabled: true
+            tags: {}
+
+        # Default origin groups configuration
+        origin_groups:
+          default:
+            name: "default-origin-group"
+            session_affinity_enabled: false
+            load_balancing:
+              sample_size: 4
+              successful_samples_required: 3
+              additional_latency_in_milliseconds: 50
+            health_probe:
+              protocol: "Https"
+              interval_in_seconds: 100
+              request_type: "HEAD"
+              path: "/health"
+
+        # Default origins configuration (to be overridden per environment)
+        origins: {}
+
+        # Default routes configuration (to be overridden per environment)
+        routes: {}
+
+        # Default rule sets (empty by default)
+        rule_sets: {}
+
+        # Default rules (empty by default)
+        rules: {}
+
+        # Default custom domains (empty by default)
+        custom_domains: {}
+
+        # Default security policies (empty by default)
+        security_policies: {}

--- a/atmos/stacks/catalog/azure-frontdoor/mixins/dev.yaml
+++ b/atmos/stacks/catalog/azure-frontdoor/mixins/dev.yaml
@@ -1,0 +1,26 @@
+components:
+  terraform:
+    azure-frontdoor:
+      vars:
+        stage: "dev"
+
+        # Development uses Standard SKU for cost savings
+        sku_name: "Standard_AzureFrontDoor"
+
+        # Shorter timeout for development
+        response_timeout_seconds: 60
+
+        # Development-specific origin groups
+        origin_groups:
+          default:
+            name: "dev-origin-group"
+            session_affinity_enabled: false
+            load_balancing:
+              sample_size: 2
+              successful_samples_required: 1
+              additional_latency_in_milliseconds: 50
+            health_probe:
+              protocol: "Https"
+              interval_in_seconds: 120
+              request_type: "HEAD"
+              path: "/health"

--- a/atmos/stacks/catalog/azure-frontdoor/mixins/prod.yaml
+++ b/atmos/stacks/catalog/azure-frontdoor/mixins/prod.yaml
@@ -1,0 +1,26 @@
+components:
+  terraform:
+    azure-frontdoor:
+      vars:
+        stage: "prod"
+
+        # Production uses Premium SKU for advanced features
+        sku_name: "Premium_AzureFrontDoor"
+
+        # Standard timeout for production
+        response_timeout_seconds: 120
+
+        # Production-specific origin groups with stricter health checks
+        origin_groups:
+          default:
+            name: "prod-origin-group"
+            session_affinity_enabled: true
+            load_balancing:
+              sample_size: 4
+              successful_samples_required: 3
+              additional_latency_in_milliseconds: 50
+            health_probe:
+              protocol: "Https"
+              interval_in_seconds: 60
+              request_type: "HEAD"
+              path: "/health"


### PR DESCRIPTION
This commit adds a new Azure Front Door (Standard/Premium) component following the repository's patterns and standards.

Features:
- Complete Front Door Profile configuration (Standard and Premium SKUs)
- Endpoints with customizable settings
- Origin Groups with load balancing and health probes
- Origins with Private Link support
- Routes with caching and custom domain support
- Rule Sets and Rules for traffic manipulation
- Custom Domains with TLS/SSL configuration
- Security Policies for WAF integration
- Comprehensive variables with validation
- Detailed outputs for downstream components
- Stack catalog with defaults and environment-specific mixins (dev/prod)

Technical details:
- Based on azurerm provider 4.20.0
- Uses Cloud Posse label module v0.25.0 for consistent naming
- Formatted with terraform fmt -recursive
- Includes comprehensive README with usage examples
- Follows repository naming conventions and structure

Files added:
- Component module: atmos/components/terraform/modules/azure-frontdoor/
- Stack catalog: atmos/stacks/catalog/azure-frontdoor/

## Summary
<!-- Brief description of what this PR accomplishes -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code cleanup/refactoring
- [ ] 🚀 Performance improvement

## Changes Made
<!-- List the key changes in this PR -->
- 
- 

## Components/Stacks Affected
<!-- List any Atmos components or stacks modified -->
- 

## Notes
<!-- Any additional context, considerations, or follow-up items -->

---
*Atmos validation and testing will run automatically via GitHub Actions*
